### PR TITLE
ci(github-actions): add workflow to build NextJS project

### DIFF
--- a/.github/workflows/nextjsBuild.yml
+++ b/.github/workflows/nextjsBuild.yml
@@ -1,0 +1,179 @@
+name: NextJS Build
+on: push
+
+env:
+  YARN_MODULES_CACHE_KEY: v1
+  YARN_PACKAGE_CACHE_KEY: v1
+  YARN_CACHE_FOLDER: .cache/yarn
+  FORCE_COLOR: true # display terminal colors
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: "! contains(toJSON(github.event.head_commit.message), '[skip ci]')" # skip job if git message contains [skip ci]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Install npm dependencies
+        run: yarn install
+
+  # lint:
+  #   needs: install
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 10
+  #   steps:
+  #     - uses: actions/checkout@v2
+
+  #     - name: Cache node modules
+  #       uses: actions/cache@v2
+  #       env:
+  #         cache-name: cache-node-modules
+  #       with:
+  #         path: '**/node_modules'
+  #         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+  #         restore-keys: ${{ runner.os }}-build-${{ env.cache-name }}-
+
+  #     - name: Lint project
+  #       run: yarn lint
+
+  # test:
+  #   needs: install
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 10
+  #   steps:
+  #     - uses: actions/checkout@v2
+
+  #     - name: Cache node modules
+  #       uses: actions/cache@v2
+  #       env:
+  #         cache-name: cache-node-modules
+  #       with:
+  #         path: '**/node_modules'
+  #         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+  #           ${{ runner.os }}-build-${{ env.cache-name }}-
+
+  #     - name: Test project
+  #       run: yarn test --maxWorkers=2 --ci --coverage
+
+  #     - name: Archive test results
+  #       uses: actions/upload-artifact@v1
+  #       with:
+  #         name: test-results
+  #         path: test-results/test-report.html
+
+  #     - name: Archive code coverage
+  #       uses: actions/upload-artifact@v1
+  #       with:
+  #         name: code-coverage
+  #         path: coverage/lcov-report/
+
+  #     - name: Upload coverage to Codecov
+  #       uses: codecov/codecov-action@v1.0.7
+  #       with:
+  #         token: ${{ secrets.CODECOV_TOKEN }}
+  #         file: coverage/lcov.info
+
+  # build:
+  #   needs: install
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+
+  #     - name: Cache node modules
+  #       uses: actions/cache@v2
+  #       env:
+  #         cache-name: cache-node-modules
+  #       with:
+  #         path: '**/node_modules'
+  #         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+  #         restore-keys: ${{ runner.os }}-build-${{ env.cache-name }}-
+
+  #     - name: Create properties file
+  #       run: |
+  #         printf 'RELEASE_KEY_STORE=%s\n' ${{ secrets.RELEASE_KEY_STORE }} >> android/release-keystore.properties
+  #         printf 'RELEASE_KEY_ALIAS_NAME=%s\n' '${{ secrets.RELEASE_KEY_ALIAS_NAME }}' >> android/release-keystore.properties
+  #         printf 'RELEASE_KEY_ALIAS_PASSWORD=%s\n' '${{ secrets.RELEASE_KEY_ALIAS_PASSWORD }}' >> android/release-keystore.properties
+  #         printf 'RELEASE_KEY_STORE_PASSWORD=%s\n' '${{ secrets.RELEASE_KEY_STORE_PASSWORD }}' >> android/release-keystore.properties
+
+  #     - name: Decode Android key
+  #       run: |
+  #         echo "${{ secrets.KEYSTORE }}" > keystore-base64
+  #         base64 -d -i keystore-base64 > android/app/release.keystore
+
+  #     - name: Cache Android dependencies
+  #       uses: actions/cache@v2
+  #       env:
+  #         cache-name: cache-android-dependencies
+  #       with:
+  #         path: |
+  #           ~/.gradle/
+  #           ~/.m2/
+  #         key: jars-{{ hashFiles('android/gradle/wrapper/gradle-wrapper.properties') }}-{{ hashFiles("android/build.gradle") }}-{{ hashFiles('android/app/build.gradle') }}
+  #         restore-keys: jars-{{ hashFiles('android/gradle/wrapper/gradle-wrapper.properties') }}-{{ hashFiles("android/build.gradle") }}-
+
+  #     - name: Download Android dependencies
+  #       run: |
+  #         cd android
+  #         ./gradlew androidDependencies
+  #         cd ..
+
+  #     - name: Generate .ENV file
+  #       run: |
+  #         printf 'BUILD_VERSION=%s\n' $(echo ${{ github.sha }} | cut -c -7) >> .env
+  #         printf 'API_KEY=%s\n' '${{ secrets.API_KEY }}' >> .env
+  #         printf 'DEV_API_KEY=%s\n' '${{ secrets.DEV_API_KEY }}' >> .env
+
+  #     - name: Update semantic-version in package.json
+  #       # NOTE: this will run successfully on master branch. on any other branch it will use the current npm version
+  #       # run semantic-version in dry-run mode
+  #       # extract string that starts with "Release note"
+  #       # extract version number
+  #       # update version using "npm version"
+  #       run: |
+  #         yarn semantic-release -d | grep 'Release note' | grep -Po "(\d+)\.(\d+)\.(\d+)" | xargs npm version --allow-same-version --no-git-tag-version
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  #     - name: Build Android APK
+  #       run: yarn build:android:release
+
+  #     - name: Upload Artifact
+  #       uses: actions/upload-artifact@v1
+  #       with:
+  #         name: app-release.apk
+  #         path: android/app/build/outputs/apk/release/
+
+  release:
+    # needs: build
+    needs: install
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: semantic-release
+        if: github.ref == 'refs/heads/master'
+        run: yarn semantic-release --dry-run ${{github.ref != 'refs/heads/master'}} --ci ${{github.ref == 'refs/heads/master'}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
NOTE:
Currently it installs `node_modules` and runs `semantic-release`.

Later it needs to have a build job and dockerize job

NOTE: using template from https://gist.github.com/Clumsy-Coder/dc8c35e5402d214510a24a6e1c3db8f2
This is ReactJS project. So the steps in 'build' job are not relevant. It will be dealt with later on.