### PR TITLE
fix(semantic-release): add plugin to create a release after generating Changelog

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -19,6 +19,7 @@ module.exports = {
         ],
       },
     ],
+    "@semantic-release/github",
     [
       "@semantic-release/git",
       {


### PR DESCRIPTION
Forgot to add @semantic-release/github plugin

Should now create github release on master branch