### PR TITLE
Jss csp hotfix

### DIFF
--- a/.nginx/default.conf
+++ b/.nginx/default.conf
@@ -43,9 +43,22 @@ server {
 
   add_header 'Referrer-Policy' 'no-referrer';
 
+  # NOTE: Content Security Policy is defined in src/pages/_document.tsx
+  #       this is due to the need of using a nonce.
+  #       defining CSP here will override the CSP in src/pages/_document.tsx
   # Content Security Policy (CSP) and X-XSS-Protection (XSS)
-  add_header Content-Security-Policy "default-src 'none'; script-src 'self'; object-src 'none'; style-src 'none'; form-action 'none'; frame-ancestors 'none'; base-uri 'none';" always;
+  # add_header Content-Security-Policy "
+  # default-src 'self'; 
+  # script-src 'self'; 
+  # object-src 'none'; 
+  # style-src 'self' https://fonts.googleapis.com ; 
+  # font-src fonts.gstatic.com ;
+  # form-action 'none'; 
+  # frame-ancestors 'none'; 
+  # base-uri 'none';" always;
   add_header X-XSS-Protection "1; mode=block";
+
+  add_header 'X-Download-Options' "noopen";
 
   ssl_protocols TLSv1.2 TLSv1.3;
   ssl_prefer_server_ciphers on;

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  poweredByHeader: false,
+};

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "@material-ui/icons": "^4.11.2",
     "next": "^10.0.5",
     "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "react-dom": "^17.0.1",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@google/semantic-release-replace-plugin": "^1.0.2",
@@ -34,6 +35,7 @@
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/jest": "^26.0.20",
     "@types/react": "^17.0.0",
+    "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^4.14.0",
     "@typescript-eslint/parser": "^4.14.0",
     "babel-jest": "^26.6.3",

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,15 +1,47 @@
 import React from 'react';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 import { ServerStyleSheets } from '@material-ui/core/styles';
-import theme from '../utils/theme';
+import crypto from 'crypto';
+import { v4 } from 'uuid';
+
+import theme from '@utils/theme';
+
+/**
+ * Generate Content Security Policy for the app.
+ * Uses randomly generated nonce (base64)
+ *
+ * @returns [csp: string, nonce: string] - CSP string in first array element, nonce in the second array element.
+ */
+const generateCsp = (): [csp: string, nonce: string] => {
+  const production = process.env.NODE_ENV === 'production';
+
+  // generate random nonce converted to base64. Must be different on every HTTP page load
+  const hash = crypto.createHash('sha256');
+  hash.update(v4());
+  const nonce = hash.digest('base64');
+
+  let csp = ``;
+  csp += `default-src 'none';`;
+  csp += `base-uri 'self';`;
+  csp += `style-src https://fonts.googleapis.com 'unsafe-inline';`; // NextJS requires 'unsafe-inline'
+  csp += `script-src 'nonce-${nonce}' 'self' ${production ? '' : "'unsafe-eval'"};`; // NextJS requires 'self' and 'unsafe-eval' in dev (faster source maps)
+  csp += `font-src https://fonts.gstatic.com;`;
+  if (!production) csp += `connect-src 'self';`;
+
+  return [csp, nonce];
+};
 
 export default class MyDocument extends Document {
   render(): JSX.Element {
+    const [csp, nonce] = generateCsp();
+
     return (
       <Html lang='en'>
-        <Head>
+        <Head nonce={nonce}>
           {/* PWA primary color */}
           <meta name='theme-color' content={theme.palette.primary.main} />
+          <meta property='csp-nonce' content={nonce} />
+          <meta httpEquiv='Content-Security-Policy' content={csp} />
           <link
             rel='stylesheet'
             href='https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap'
@@ -17,7 +49,7 @@ export default class MyDocument extends Document {
         </Head>
         <body>
           <Main />
-          <NextScript />
+          <NextScript nonce={nonce} />
         </body>
       </Html>
     );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -84,5 +84,6 @@
     "**/*.tsx",
     "semanticRelease/commitRules.js",
     "semanticRelease/commitTypes.js", 
+    "next.config.js"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1176,6 +1176,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
 
+"@types/uuid@^8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
+  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
+
 "@types/yargs-parser@*":
   version "20.2.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.0.tgz#dd3e6699ba3237f0348cd085e4698780204842f9"
@@ -10955,7 +10960,7 @@ uuid@^3.3.2, uuid@^3.3.3:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.3.0:
+uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
- [x] Create stricter Content Security Policy
- [x] Generate randomly generated nonce using uuid v4 converted to base64
  - [x] nonce must be randomly generated on every HTTP request (ex: visit app site twice should have two different nonce values) 
- [x] Apply nonce to rendered components in `src/pages/_document.tsx` 
- [x] Disable Content Security policy in nginx config
- [x] Hide `x-powered-by` HTTP header