### PR TITLE
ci(github-actions): change the username to github.repository_owner

### DIFF
--- a/.github/workflows/nextjsBuild.yml
+++ b/.github/workflows/nextjsBuild.yml
@@ -168,7 +168,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Build Docker images


### PR DESCRIPTION
It was using incorrect username when the commit was created by Dependabot (for npm package upgrade).
Changed to using the owner of the repo instead.